### PR TITLE
Minor bugfix: $label from dump() ended with ) in some situations

### DIFF
--- a/dahbug.php
+++ b/dahbug.php
@@ -815,7 +815,9 @@ class dahbug
             $label = $file[$backtrace[0]['line']-1];
             $label = trim($label);
             $label = substr($label, strpos($label, 'dahbug') + 13);
-            if (strpos($label, ',')) {
+            if (strpos($label, '),') < strpos($label, ',')) {
+                $label = substr($label, 0, strpos($label, '),'));
+            } else if (strpos($label, ',')) {
                 $label = substr($label, 0, strpos($label, ','));
             } else {
                 $label = substr($label, 0, strpos($label, ');'));


### PR DESCRIPTION
When using the dump function in the following example, `$type)` would be used as a label.

``` php
$block = $this->_getBlockInstance(dahbug::dump($type), $attributes);
```
