### PR TITLE
Reset all attributes after colorization

### DIFF
--- a/dahbug.php
+++ b/dahbug.php
@@ -955,7 +955,7 @@ class dahbug
             return $string;
         }
 
-        $string = "\033[{$colorNumber}m" . $string . "\033[39m";
+        $string = "\033[{$colorNumber}m" . $string . "\033[0m";
 
         return $string;
     }


### PR DESCRIPTION
Code 39 only resets the color to the default one, which leaves part of strings bold after using light_\* colors.
