### PR TITLE
Added space to private and protected properties when dumping objects

### DIFF
--- a/dahbug.php
+++ b/dahbug.php
@@ -773,6 +773,7 @@ class dahbug
                             $string .= '  ';
                         }
                         $string .= str_repeat(' ', ($recursion + 1) * self::getData('indent'));
+                        $key = str_replace("\0", ' ', ltrim($key, "\0"));
                         $string .= self::_prepareLabel($key, 'key_property') . ' => ';
                         $string .= self::_formatVar($value, $recursion + 1, $maxDepth);
                     }


### PR DESCRIPTION
PHP adds null bytes to private and protected properties when converting objects to arrays (https://www.php.net/manual/en/language.types.array.php#language.types.array.casting). With a simple string replace we can make these more legible, especially private properties.

Before:
```
30  [$c] = (object:3) testclass
      [testclassprivate] => (int) 1
      [*protected] => (int) 2
      [public] => (int) 3
```
After:
```
30  [$c] = (object:3) testclass
      [testclass private] => (int) 1
      [* protected] => (int) 2
      [public] => (int) 3
```